### PR TITLE
App içerisinde alertlerin daha kolay olusturulabilmesi icin refactor.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/ArdOnat/CoreModule.git",
         "state": {
           "branch": null,
-          "revision": "c6b698e66082043b4725294ec80b603d50a90990",
-          "version": "1.3.7"
+          "revision": "df40238ad22893a8f95bbb02d6bf6f39a37e32e0",
+          "version": "1.3.8"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/ArdOnat/CoreModule.git", .exact("1.3.7")),
+        .package(url: "https://github.com/ArdOnat/CoreModule.git", .exact("1.3.8")),
         .package(name: "Validator", url: "https://github.com/adamwaite/Validator.git", branch: "master")
     ],
     targets: [

--- a/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertBuilder.swift
+++ b/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertBuilder.swift
@@ -25,20 +25,18 @@ public class AlertViewControllerBuilder: AlertBuilding {
     }
 
     private func buildDefaultAlertViewController(with viewData: DefaultAlertModel) -> AppHereAlertViewController {
-        let viewController = AppHereAlertViewController.loadFromNib()
-        viewController.presentableModel = viewData
+        let viewController = AppHereAlertViewController(presentableModel: viewData)
         return viewController
     }
 
     private func buildInputAlertViewController(with viewData: InputAlertModel) -> AppHereInputAlertViewController {
-        let viewController = AppHereInputAlertViewController.loadFromNib()
-        viewController.presentableModel = viewData
+        let viewController = AppHereInputAlertViewController(presentableModel: viewData)
         return viewController
     }
 }
 
 private extension UIViewController {
-    static func loadFromNib() -> Self {
+    func loadFromNib() -> Self {
         func instantiateFromNib<T: UIViewController>() -> T {
             T(nibName: String(describing: T.self), bundle: .module)
         }

--- a/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertBuilder.swift
+++ b/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertBuilder.swift
@@ -1,35 +1,19 @@
 import UIKit
 
-public protocol AlertModel {
-    var imageName: String { get }
-    var titleText: String { get }
-    var descriptionText: String? { get }
-    var leftButtonTitle: String? { get }
-    var rightButtonTitle: String? { get }
-}
-
 public protocol AlertBuilding {
-    func buildAlertViewController(with alertModel: AlertModel) -> UIViewController?
+    func buildDefaultAlertViewController(with viewData: DefaultAlertModel) -> AppHereAlertViewController
+    func buildInputAlertViewController(with viewData: InputAlertModel) -> AppHereInputAlertViewController
 }
 
 public class AlertViewControllerBuilder: AlertBuilding {
     public init() {}
 
-    public func buildAlertViewController(with alertModel: AlertModel) -> UIViewController? {
-        if let defaultAlertModel = alertModel as? DefaultAlertModel {
-            return buildDefaultAlertViewController(with: defaultAlertModel)
-        } else if let inputAlertModel = alertModel as? InputAlertModel {
-            return buildInputAlertViewController(with: inputAlertModel)
-        }
-        return nil
-    }
-
-    private func buildDefaultAlertViewController(with viewData: DefaultAlertModel) -> AppHereAlertViewController {
+    public func buildDefaultAlertViewController(with viewData: DefaultAlertModel) -> AppHereAlertViewController {
         let viewController = AppHereAlertViewController(presentableModel: viewData)
         return viewController
     }
 
-    private func buildInputAlertViewController(with viewData: InputAlertModel) -> AppHereInputAlertViewController {
+    public func buildInputAlertViewController(with viewData: InputAlertModel) -> AppHereInputAlertViewController {
         let viewController = AppHereInputAlertViewController(presentableModel: viewData)
         return viewController
     }

--- a/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertBuilder.swift
+++ b/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertBuilder.swift
@@ -18,13 +18,3 @@ public class AlertViewControllerBuilder: AlertBuilding {
         return viewController
     }
 }
-
-private extension UIViewController {
-    func loadFromNib() -> Self {
-        func instantiateFromNib<T: UIViewController>() -> T {
-            T(nibName: String(describing: T.self), bundle: .module)
-        }
-
-        return instantiateFromNib()
-    }
-}

--- a/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertViewController/AppHereAlertViewController.swift
+++ b/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertViewController/AppHereAlertViewController.swift
@@ -2,50 +2,6 @@ import UIKit
 
 public typealias AlertButtonHandler = (AppHereAlertViewController) -> Void
 
-public struct DefaultAlertModel: AlertModel {
-    public let imageName: String
-    public let titleText: String
-    public let descriptionText: String?
-    public let leftButtonTitle: String?
-    public let rightButtonTitle: String?
-    public let leftButtonHandler: AlertButtonHandler?
-    public let rightButtonHandler: AlertButtonHandler?
-
-    public init(
-        imageName: String,
-        titleText: String,
-        descriptionText: String?,
-        leftButtonTitle: String?,
-        rightButtonTitle: String?,
-        leftButtonHandler: AlertButtonHandler? = nil,
-        rightButtonHandler: AlertButtonHandler? = nil
-    ) {
-        self.imageName = imageName
-        self.titleText = titleText
-        self.descriptionText = descriptionText
-        self.leftButtonTitle = leftButtonTitle
-        self.leftButtonHandler = leftButtonHandler
-        self.rightButtonTitle = rightButtonTitle
-        self.rightButtonHandler = rightButtonHandler
-    }
-
-    var isDescriptionLabelHidden: Bool {
-        descriptionText == nil
-    }
-
-    var isLeftButtonHidden: Bool {
-        leftButtonTitle == nil
-    }
-
-    var isRightButtonHidden: Bool {
-        rightButtonTitle == nil
-    }
-
-    var isButtonStackViewHidden: Bool {
-        isLeftButtonHidden && isRightButtonHidden
-    }
-}
-
 public final class AppHereAlertViewController: UIViewController {
     @IBOutlet private var alertImageView: UIImageView!
     @IBOutlet private var textStackView: UIStackView!
@@ -55,34 +11,32 @@ public final class AppHereAlertViewController: UIViewController {
     @IBOutlet private var alertLeftButton: AppHereButton!
     @IBOutlet private var alertRightButton: AppHereButton!
 
-    var presentableModel: DefaultAlertModel?
+    public var leftButtonHandler: AlertButtonHandler?
+    public var rightButtonHandler: AlertButtonHandler?
 
-    private var leftButtonHandler: AlertButtonHandler?
-    private var rightButtonHandler: AlertButtonHandler?
+    private let presentableModel: DefaultAlertModel
 
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    init(presentableModel: DefaultAlertModel) {
+        self.presentableModel = presentableModel
+        super.init(nibName: String(describing: AppHereAlertViewController.self), bundle: .module)
     }
 
     override public func viewDidLoad() {
         super.viewDidLoad()
-        alertImageView.image = UIImage(named: presentableModel!.imageName)
+        alertImageView.image = UIImage(named: presentableModel.imageName)
 
-        alertTitleLabel.text = presentableModel!.titleText
+        alertTitleLabel.text = presentableModel.titleText
 
-        alertDescriptionLabel.isHidden = presentableModel!.isDescriptionLabelHidden
-        alertDescriptionLabel.text = presentableModel!.descriptionText
+        alertDescriptionLabel.isHidden = presentableModel.isDescriptionLabelHidden
+        alertDescriptionLabel.text = presentableModel.descriptionText
 
-        buttonStackView.isHidden = presentableModel!.isButtonStackViewHidden
+        buttonStackView.isHidden = presentableModel.isButtonStackViewHidden
 
-        alertLeftButton.isHidden = presentableModel!.isLeftButtonHidden
-        alertLeftButton.setTitle(presentableModel!.leftButtonTitle, for: .normal)
+        alertLeftButton.isHidden = presentableModel.isLeftButtonHidden
+        alertLeftButton.setTitle(presentableModel.leftButtonTitle, for: .normal)
 
-        alertRightButton.isHidden = presentableModel!.isRightButtonHidden
-        alertRightButton.setTitle(presentableModel!.rightButtonTitle, for: .normal)
-
-        leftButtonHandler = presentableModel!.leftButtonHandler
-        rightButtonHandler = presentableModel!.rightButtonHandler
+        alertRightButton.isHidden = presentableModel.isRightButtonHidden
+        alertRightButton.setTitle(presentableModel.rightButtonTitle, for: .normal)
     }
 
     @available(*, unavailable)

--- a/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertViewController/AppHereAlertViewController.swift
+++ b/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertViewController/AppHereAlertViewController.swift
@@ -25,6 +25,7 @@ public final class AppHereAlertViewController: UIViewController {
         super.viewDidLoad()
         alertImageView.image = UIImage(named: presentableModel.imageName)
 
+        alertTitleLabel.isHidden = presentableModel.isTitleLabelHidden
         alertTitleLabel.text = presentableModel.titleText
 
         alertDescriptionLabel.isHidden = presentableModel.isDescriptionLabelHidden

--- a/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertViewController/DefaultAlertModel.swift
+++ b/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertViewController/DefaultAlertModel.swift
@@ -1,0 +1,37 @@
+public struct DefaultAlertModel: AlertModel {
+    public let imageName: String
+    public let titleText: String
+    public let descriptionText: String?
+    public let leftButtonTitle: String?
+    public let rightButtonTitle: String?
+
+    public init(
+        imageName: String,
+        titleText: String,
+        descriptionText: String?,
+        leftButtonTitle: String?,
+        rightButtonTitle: String?
+    ) {
+        self.imageName = imageName
+        self.titleText = titleText
+        self.descriptionText = descriptionText
+        self.leftButtonTitle = leftButtonTitle
+        self.rightButtonTitle = rightButtonTitle
+    }
+
+    var isDescriptionLabelHidden: Bool {
+        descriptionText == nil
+    }
+
+    var isLeftButtonHidden: Bool {
+        leftButtonTitle == nil
+    }
+
+    var isRightButtonHidden: Bool {
+        rightButtonTitle == nil
+    }
+
+    var isButtonStackViewHidden: Bool {
+        isLeftButtonHidden && isRightButtonHidden
+    }
+}

--- a/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertViewController/DefaultAlertModel.swift
+++ b/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertViewController/DefaultAlertModel.swift
@@ -1,4 +1,4 @@
-public struct DefaultAlertModel: AlertModel {
+public struct DefaultAlertModel {
     public let imageName: String
     public let titleText: String
     public let descriptionText: String?

--- a/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertViewController/DefaultAlertModel.swift
+++ b/Sources/AppHereComponents/Components/AppHereAlerts/AppHereAlertViewController/DefaultAlertModel.swift
@@ -1,13 +1,13 @@
 public struct DefaultAlertModel {
     public let imageName: String
-    public let titleText: String
+    public let titleText: String?
     public let descriptionText: String?
     public let leftButtonTitle: String?
     public let rightButtonTitle: String?
 
     public init(
         imageName: String,
-        titleText: String,
+        titleText: String?,
         descriptionText: String?,
         leftButtonTitle: String?,
         rightButtonTitle: String?
@@ -17,6 +17,10 @@ public struct DefaultAlertModel {
         self.descriptionText = descriptionText
         self.leftButtonTitle = leftButtonTitle
         self.rightButtonTitle = rightButtonTitle
+    }
+
+    var isTitleLabelHidden: Bool {
+        titleText == nil
     }
 
     var isDescriptionLabelHidden: Bool {

--- a/Sources/AppHereComponents/Components/AppHereAlerts/AppHereInputAlertViewController/InputAlertModel.swift
+++ b/Sources/AppHereComponents/Components/AppHereAlerts/AppHereInputAlertViewController/InputAlertModel.swift
@@ -1,4 +1,4 @@
-public struct InputAlertModel: AlertModel {
+public struct InputAlertModel {
     public let imageName: String
     public let titleText: String
     public let descriptionText: String?

--- a/Sources/AppHereComponents/Components/AppHereAlerts/AppHereInputAlertViewController/InputAlertModel.swift
+++ b/Sources/AppHereComponents/Components/AppHereAlerts/AppHereInputAlertViewController/InputAlertModel.swift
@@ -1,0 +1,53 @@
+public struct InputAlertModel: AlertModel {
+    public let imageName: String
+    public let titleText: String
+    public let descriptionText: String?
+    public let textFieldPlaceHolder: String?
+    public let leftButtonTitle: String?
+    public let rightButtonTitle: String?
+    public let centerButtonTitle: String?
+    public let isSecureEntry: Bool
+    public let isFillingMandatory: Bool
+
+    public init(
+        imageName: String,
+        titleText: String,
+        descriptionText: String?,
+        textFieldPlaceHolder: String?,
+        leftButtonTitle: String?,
+        rightButtonTitle: String?,
+        centerButtonTitle: String?,
+        isSecureEntry: Bool,
+        isFillingMandatory: Bool = true
+    ) {
+        self.imageName = imageName
+        self.titleText = titleText
+        self.descriptionText = descriptionText
+        self.textFieldPlaceHolder = textFieldPlaceHolder
+        self.leftButtonTitle = leftButtonTitle
+        self.rightButtonTitle = rightButtonTitle
+        self.centerButtonTitle = centerButtonTitle
+        self.isSecureEntry = isSecureEntry
+        self.isFillingMandatory = isFillingMandatory
+    }
+
+    var isDescriptionLabelHidden: Bool {
+        descriptionText == nil
+    }
+
+    var isLeftButtonHidden: Bool {
+        leftButtonTitle == nil
+    }
+
+    var isRightButtonHidden: Bool {
+        rightButtonTitle == nil
+    }
+
+    var isCenterButtonHidden: Bool {
+        centerButtonTitle == nil
+    }
+
+    var isButtonStackViewHidden: Bool {
+        isLeftButtonHidden && isRightButtonHidden
+    }
+}

--- a/Sources/AppHereComponents/Components/ApphereAlerts/AppHereInputAlertViewController/AppHereInputAlertViewController.swift
+++ b/Sources/AppHereComponents/Components/ApphereAlerts/AppHereInputAlertViewController/AppHereInputAlertViewController.swift
@@ -2,69 +2,6 @@ import UIKit
 
 public typealias InputAlertButtonHandler = (AppHereInputAlertViewController) -> Void
 
-public struct InputAlertModel: AlertModel {
-    public let imageName: String
-    public let titleText: String
-    public let descriptionText: String?
-    public let textFieldPlaceHolder: String?
-    public let leftButtonTitle: String?
-    public let rightButtonTitle: String?
-    public let centerButtonTitle: String?
-    public let isSecureEntry: Bool
-    public let isFillingMandatory: Bool
-    public let leftButtonHandler: InputAlertButtonHandler?
-    public let rightButtonHandler: InputAlertButtonHandler?
-    public let centerButtonHandler: InputAlertButtonHandler?
-
-    public init(
-        imageName: String,
-        titleText: String,
-        descriptionText: String?,
-        textFieldPlaceHolder: String?,
-        leftButtonTitle: String?,
-        rightButtonTitle: String?,
-        centerButtonTitle: String?,
-        isSecureEntry: Bool,
-        isFillingMandatory: Bool = true,
-        leftButtonHandler: InputAlertButtonHandler?,
-        rightButtonHandler: InputAlertButtonHandler?,
-        centerButtonHandler: InputAlertButtonHandler?
-    ) {
-        self.imageName = imageName
-        self.titleText = titleText
-        self.descriptionText = descriptionText
-        self.textFieldPlaceHolder = textFieldPlaceHolder
-        self.leftButtonTitle = leftButtonTitle
-        self.rightButtonTitle = rightButtonTitle
-        self.centerButtonTitle = centerButtonTitle
-        self.isSecureEntry = isSecureEntry
-        self.isFillingMandatory = isFillingMandatory
-        self.leftButtonHandler = leftButtonHandler
-        self.rightButtonHandler = rightButtonHandler
-        self.centerButtonHandler = centerButtonHandler
-    }
-
-    var isDescriptionLabelHidden: Bool {
-        descriptionText == nil
-    }
-
-    var isLeftButtonHidden: Bool {
-        leftButtonTitle == nil
-    }
-
-    var isRightButtonHidden: Bool {
-        rightButtonTitle == nil
-    }
-
-    var isCenterButtonHidden: Bool {
-        centerButtonTitle == nil
-    }
-
-    var isButtonStackViewHidden: Bool {
-        isLeftButtonHidden && isRightButtonHidden
-    }
-}
-
 public final class AppHereInputAlertViewController: UIViewController {
     @IBOutlet private var alertImageView: UIImageView!
     @IBOutlet private var alertTitleLabel: AppHereLabel!
@@ -74,53 +11,51 @@ public final class AppHereInputAlertViewController: UIViewController {
     @IBOutlet private var alertRightButton: AppHereButton!
     @IBOutlet private var alertCenterButton: UIButton!
 
-    var presentableModel: InputAlertModel?
+    public var leftButtonHandler: InputAlertButtonHandler?
+    public var rightButtonHandler: InputAlertButtonHandler?
+    public var centerButtonHandler: InputAlertButtonHandler?
 
     public var inputtedText: String {
         alertInputTextField.text.valueOrEmpty
     }
 
-    private var leftButtonHandler: InputAlertButtonHandler?
-    private var rightButtonHandler: InputAlertButtonHandler?
-    private var centerButtonHandler: InputAlertButtonHandler?
+    private let presentableModel: InputAlertModel
 
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    init(presentableModel: InputAlertModel) {
+        self.presentableModel = presentableModel
+        super.init(nibName: String(describing: AppHereInputAlertViewController.self), bundle: .module)
     }
 
     override public func viewDidLoad() {
         super.viewDidLoad()
 
-        alertImageView.image = UIImage(named: presentableModel!.imageName)
-        alertTitleLabel.text = presentableModel!.titleText
-        alertInputTextField.placeholder = presentableModel!.textFieldPlaceHolder
+        alertImageView.image = UIImage(named: presentableModel.imageName)
+        alertTitleLabel.text = presentableModel.titleText
+        alertInputTextField.placeholder = presentableModel.textFieldPlaceHolder
+
         if #available(iOS 13.0, *) {
             alertInputTextField.overrideUserInterfaceStyle = .light
         }
 
-        alertDescriptionLabel.isHidden = presentableModel!.isDescriptionLabelHidden
-        alertDescriptionLabel.text = presentableModel!.descriptionText
+        alertDescriptionLabel.isHidden = presentableModel.isDescriptionLabelHidden
+        alertDescriptionLabel.text = presentableModel.descriptionText
 
-        alertInputTextField.isSecureTextEntry = presentableModel!.isSecureEntry
+        alertInputTextField.isSecureTextEntry = presentableModel.isSecureEntry
 
-        alertLeftButton.isHidden = presentableModel!.isLeftButtonHidden
-        alertLeftButton.setTitle(presentableModel!.leftButtonTitle, for: .normal)
+        alertLeftButton.isHidden = presentableModel.isLeftButtonHidden
+        alertLeftButton.setTitle(presentableModel.leftButtonTitle, for: .normal)
 
-        alertRightButton.isHidden = presentableModel!.isRightButtonHidden
-        alertRightButton.setTitle(presentableModel!.rightButtonTitle, for: .normal)
+        alertRightButton.isHidden = presentableModel.isRightButtonHidden
+        alertRightButton.setTitle(presentableModel.rightButtonTitle, for: .normal)
 
-        alertCenterButton.isHidden = presentableModel!.isCenterButtonHidden
-        alertCenterButton.setTitle(presentableModel!.centerButtonTitle, for: .normal)
+        alertCenterButton.isHidden = presentableModel.isCenterButtonHidden
+        alertCenterButton.setTitle(presentableModel.centerButtonTitle, for: .normal)
 
-        leftButtonHandler = presentableModel!.leftButtonHandler
-        rightButtonHandler = presentableModel!.rightButtonHandler
-        centerButtonHandler = presentableModel!.centerButtonHandler
-
-        if presentableModel!.isSecureEntry {
+        if presentableModel.isSecureEntry {
             alertInputTextField.enablePasswordToggle()
         }
 
-        if presentableModel!.isFillingMandatory {
+        if presentableModel.isFillingMandatory {
             alertRightButton.isUserInteractionEnabled = false
             alertRightButton.alpha = 0.6
             alertInputTextField.addTarget(
@@ -143,7 +78,7 @@ public final class AppHereInputAlertViewController: UIViewController {
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {
-        super.init(coder: coder)
+        fatalError()
     }
 
     func enablePasswordToggle() {


### PR DESCRIPTION
Alert olusturma logici iOSAppHereComponents kutuphanesine tasindi. ooAutos tarafindaki kaldirilacak.

AlertViewControllerBuilder AlertBuilding protocolune conform ederek

    func buildDefaultAlertViewController(with viewData: DefaultAlertModel) -> AppHereAlertViewController
    func buildInputAlertViewController(with viewData: InputAlertModel) -> AppHereInputAlertViewController
    
implementasyonlarini oluşturuyor.
    
Buradan sonra appteki butun alertler bu class uzerinden oluşturulacak.    

AppHereAlertViewController ve AppHereInputAlertViewController presentableModel olmadan calisamiyorlardi ve burada force unwrapler vardi. Buraya iyileştirmek icin her iki class icin de yeni bir initialiser oluşturdum.

```
    private let presentableModel: DefaultAlertModel

    init(presentableModel: DefaultAlertModel) {
        self.presentableModel = presentableModel
        super.init(nibName: String(describing: AppHereAlertViewController.self), bundle: .module)
    }

```

```
    private let presentableModel: InputAlertModel

    init(presentableModel: InputAlertModel) {
        self.presentableModel = presentableModel
        super.init(nibName: String(describing: AppHereInputAlertViewController.self), bundle: .module)
    }
```


Asagidaki fonksiyon kaldirildi çünkü artık kullanılmıyor.

```
private extension UIViewController {
    static func loadFromNib() -> Self {
        func instantiateFromNib<T: UIViewController>() -> T {
            T(nibName: String(describing: T.self), bundle: .module)
        }

        return instantiateFromNib()
    }
}
```